### PR TITLE
Fix: skip transcript library save for ongoing transcription chunks

### DIFF
--- a/src/main/ipcHandlers.js
+++ b/src/main/ipcHandlers.js
@@ -439,7 +439,8 @@ class IPCHandlers {
                 message: 'Transcription completed successfully' 
             });
 
-            if (!options.skipStore) {
+            const skipStore = !!(options && typeof options === 'object' && options.skipStore === true);
+            if (!skipStore) {
                 this.transcriptionStoreService.store(result.text, {
                     language: result.language,
                     duration: result.duration,

--- a/src/main/ipcHandlers.js
+++ b/src/main/ipcHandlers.js
@@ -373,7 +373,7 @@ class IPCHandlers {
         }
     }
 
-    async handleTranscribeAudio(event, audioData, prompt = null) {
+    async handleTranscribeAudio(event, audioData, prompt = null, options = {}) {
         try {
             // Get current configuration
             const currentConfig = config.getSimplified();
@@ -439,11 +439,13 @@ class IPCHandlers {
                 message: 'Transcription completed successfully' 
             });
 
-            this.transcriptionStoreService.store(result.text, {
-                language: result.language,
-                duration: result.duration,
-                model: currentConfig.model || ''
-            }).catch(err => console.error('Failed to auto-store transcription:', err));
+            if (!options.skipStore) {
+                this.transcriptionStoreService.store(result.text, {
+                    language: result.language,
+                    duration: result.duration,
+                    model: currentConfig.model || ''
+                }).catch(err => console.error('Failed to auto-store transcription:', err));
+            }
 
             return {
                 success: true,

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -21,7 +21,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   
     // Transcription
     transcribeFile: (filePath) => ipcRenderer.invoke('transcription:file', filePath),
-    transcribeAudio: (audioData, prompt = null) => ipcRenderer.invoke('transcription:audio', audioData, prompt),
+    transcribeAudio: (audioData, prompt = null, options = {}) => ipcRenderer.invoke('transcription:audio', audioData, prompt, options),
   
     // Configuration
     getConfig: () => ipcRenderer.invoke('config:get'),

--- a/src/renderer/controllers/RecordingController.js
+++ b/src/renderer/controllers/RecordingController.js
@@ -1429,7 +1429,7 @@ export class RecordingController {
 
                 for (let i = 0; i < wavBuffers.length; i++) {
                     try { VADMetrics.onSentSegment(1); } catch {}
-                    const subResult = await window.electronAPI.transcribeAudio(wavBuffers[i], runningPrompt || null);
+                    const subResult = await window.electronAPI.transcribeAudio(wavBuffers[i], runningPrompt || null, { skipStore: true });
                     if (subResult.success && subResult.text && subResult.text.trim()) {
                         const cleanText = subResult.text.trim();
                         console.log(`✓ Chunk ${queueItem.chunkNumber} seg ${i + 1}/${wavBuffers.length}: "${cleanText}"`);

--- a/tests/unit/ipcHandlers.test.js
+++ b/tests/unit/ipcHandlers.test.js
@@ -280,6 +280,32 @@ describe('IPCHandlers', () => {
             await expect(handlers.handleTranscribeAudio(mockEvent, audioData))
                 .rejects.toThrow('Local Whisper is not available');
         });
+
+        it('should auto-store final transcriptions by default', async () => {
+            const audioData = Buffer.from('audio data');
+            mockTranscriptionService.transcribeBuffer.mockResolvedValue({
+                success: true,
+                text: 'Hello world',
+                language: 'en'
+            });
+
+            await handlers.handleTranscribeAudio(mockEvent, audioData);
+
+            expect(handlers.transcriptionStoreService.store).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not store ongoing chunks when skipStore is true', async () => {
+            const audioData = Buffer.from('audio data');
+            mockTranscriptionService.transcribeBuffer.mockResolvedValue({
+                success: true,
+                text: 'partial chunk',
+                language: 'en'
+            });
+
+            await handlers.handleTranscribeAudio(mockEvent, audioData, null, { skipStore: true });
+
+            expect(handlers.transcriptionStoreService.store).not.toHaveBeenCalled();
+        });
     });
 
     describe('handleGetConfig', () => {


### PR DESCRIPTION
## Summary
- Ongoing-transcription background worker was saving every 1–2 line chunk to the transcript library, polluting it with partial fragments.
- Added a `skipStore` opt-out to the `transcription:audio` IPC; only the ongoing-chunk caller passes it.
- Final transcriptions (manual transcribe button, auto-transcribe after recording ends) keep auto-storing as before.
- Strict boundary validation: only `options.skipStore === true` opts out; coerced values can't suppress saving.

## Files changed
- `src/main/ipcHandlers.js` — `handleTranscribeAudio` accepts `options`; strict skipStore check.
- `src/main/preload.js` — `transcribeAudio` forwards `options` over IPC.
- `src/renderer/controllers/RecordingController.js` — ongoing-chunk call passes `{ skipStore: true }`.
- `tests/unit/ipcHandlers.test.js` — 2 regression tests.

## Test plan
- [x] `jest tests/unit/ipcHandlers.test.js` — 70/70 pass (incl. 2 new regression tests).
- [x] Auto-store happens when `skipStore` is not provided (final transcription).
- [x] No store call when `{ skipStore: true }` is passed (ongoing chunk).
- [ ] Manual smoke: start ongoing transcription, observe library — only final entry appears after stop, no per-chunk files.