### PR TITLE
Always serve renderer from src in dev mode

### DIFF
--- a/scripts/start-renderer.js
+++ b/scripts/start-renderer.js
@@ -5,10 +5,14 @@ const fs = require('fs');
 const app = express();
 const PORT = 3000;
 
-// Prefer serving from src during development; fall back to dist if present/forced
+// Always serve from src in dev so source-level changes (e.g. controller fixes)
+// take effect immediately. A stale `src/renderer/dist` from a previous build
+// would otherwise silently shadow source changes. Set USE_DIST=1 to opt in to
+// the built bundle for prod-like testing.
 const srcRoot = path.join(__dirname, '../src/renderer');
 const distRoot = path.join(__dirname, '../src/renderer/dist');
-const useDist = process.env.USE_DIST === '1' || (fs.existsSync(distRoot) && fs.existsSync(path.join(distRoot, 'index.html')));
+const distHasIndex = fs.existsSync(distRoot) && fs.existsSync(path.join(distRoot, 'index.html'));
+const useDist = process.env.USE_DIST === '1' && distHasIndex;
 const root = useDist ? distRoot : srcRoot;
 
 app.use(express.static(root));

--- a/src/renderer/controllers/SettingsController.js
+++ b/src/renderer/controllers/SettingsController.js
@@ -322,13 +322,15 @@ export class SettingsController {
             }
             
             // Get AI Refinement settings using the dedicated method
-            const aiSettings = await window.electronAPI.getAIRefinementSettings();
+            const response = await window.electronAPI.getAIRefinementSettings();
+            // Handler returns { success, settings }; tolerate either shape for robustness.
+            const aiSettings = response && response.settings ? response.settings : response;
             if (aiSettings) {
                 // Update UI elements
-                UIHelpers.setChecked('#ai-refinement-enabled-checkbox', aiSettings.enabled || false);
+                UIHelpers.setChecked('#ai-refinement-enabled-checkbox', aiSettings.enabled === true);
                 UIHelpers.setValue('#ollama-endpoint', aiSettings.endpoint || 'http://localhost:11434');
                 UIHelpers.setValue('#ollama-timeout', aiSettings.timeoutSeconds || 300);
-                
+
                 // Load available models and set selected model
                 await this.refreshOllamaModels();
                 if (aiSettings.model) {
@@ -339,7 +341,7 @@ export class SettingsController {
                 if (modelSelect && modelSelect.value && aiSettings.model && modelSelect.value !== aiSettings.model) {
                     await window.electronAPI.saveAIRefinementSettings({ model: modelSelect.value });
                 }
-                
+
                 console.log('AI Refinement settings loaded successfully');
             }
             

--- a/tests/e2e/pages/SettingsPage.ts
+++ b/tests/e2e/pages/SettingsPage.ts
@@ -7,6 +7,14 @@ export interface ModelOption {
   displayName: string;
 }
 
+/**
+ * Page object for the inline Settings panel.
+ *
+ * The settings UI is the `#settings-header` panel toggled by the
+ * SettingsController via the `visible` / `hidden` classes (see
+ * `src/renderer/styles/main.css`). The panel header text lives in
+ * `.settings-title`, not in any `.modal-header`.
+ */
 export class SettingsPage extends BasePage {
   readonly settingsBtn: Locator;
   readonly settingsModal: Locator;
@@ -18,16 +26,19 @@ export class SettingsPage extends BasePage {
   readonly translateCheckbox: Locator;
   readonly saveSettingsBtn: Locator;
   readonly cancelSettingsBtn: Locator;
+  readonly closeSettingsBtn: Locator;
   readonly modelInfoBtn: Locator;
   readonly aiRefinementEnabledCheckbox: Locator;
   readonly ollamaEndpointInput: Locator;
   readonly ollamaTimeoutInput: Locator;
+  readonly ollamaModelSelect: Locator;
 
   constructor(page: Page) {
     super(page);
     this.settingsBtn = page.locator('#settings-btn');
-    this.settingsModal = page.locator('#settings-modal');
-    this.modalHeader = page.locator('#settings-modal .modal-header h3');
+    // The settings "modal" is actually an inline panel toggled by `.visible`.
+    this.settingsModal = page.locator('#settings-header');
+    this.modalHeader = page.locator('#settings-header .settings-title');
     this.modelSelect = page.locator('#model-select');
     this.modelDescription = page.locator('#model-description');
     this.languageSelect = page.locator('#language-select');
@@ -35,15 +46,18 @@ export class SettingsPage extends BasePage {
     this.translateCheckbox = page.locator('#translate-checkbox');
     this.saveSettingsBtn = page.locator('#save-settings-btn');
     this.cancelSettingsBtn = page.locator('#cancel-settings-btn');
+    this.closeSettingsBtn = page.locator('#close-settings-btn');
     this.modelInfoBtn = page.locator('#model-info-btn');
     this.aiRefinementEnabledCheckbox = page.locator('#ai-refinement-enabled-checkbox');
     this.ollamaEndpointInput = page.locator('#ollama-endpoint');
     this.ollamaTimeoutInput = page.locator('#ollama-timeout');
+    this.ollamaModelSelect = page.locator('#ollama-model-select');
   }
 
   async openSettings() {
     await this.settingsBtn.click();
-    await expect(this.settingsModal).toBeVisible();
+    // The panel uses a class toggle, not display:none in its open state.
+    await expect(this.settingsModal).toHaveClass(/visible/);
     await expect(this.modalHeader).toContainText('Settings');
   }
 
@@ -69,9 +83,9 @@ export class SettingsPage extends BasePage {
   async verifyModelOptions() {
     await expect(this.modelSelect).toBeVisible();
     await this.waitForModelsToLoad();
-    
+
     const expectedModels = await this.getModelOptions();
-    
+
     // Verify each expected model option exists with correct pattern
     for (const model of expectedModels) {
       const option = this.modelSelect.locator(`option[value="${model.value}"]`);
@@ -81,7 +95,7 @@ export class SettingsPage extends BasePage {
         expect(optionText).toMatch(model.textPattern);
       }
     }
-    
+
     // Verify total number of options matches expected
     const allOptions = this.modelSelect.locator('option');
     await expect(allOptions).toHaveCount(expectedModels.length);
@@ -117,12 +131,12 @@ export class SettingsPage extends BasePage {
 
   async saveSettings() {
     await this.saveSettingsBtn.click();
-    // Note: Modal might stay open during download operations
-    await this.page.waitForTimeout(2000);
+    // After save, SettingsController removes `.visible` from the panel.
+    await expect(this.settingsModal).not.toHaveClass(/visible/);
   }
 
   async closeModal() {
-    // Close modal if it's still open (for cleanup)
+    // Close panel if it's still open (for cleanup)
     if (await this.isModalVisible()) {
       await this.cancelSettings();
     }
@@ -130,11 +144,12 @@ export class SettingsPage extends BasePage {
 
   async cancelSettings() {
     await this.cancelSettingsBtn.click();
-    await expect(this.settingsModal).toBeHidden();
+    await expect(this.settingsModal).not.toHaveClass(/visible/);
   }
 
   async isModalVisible(): Promise<boolean> {
-    return await this.settingsModal.isVisible();
+    const classes = (await this.settingsModal.getAttribute('class')) ?? '';
+    return classes.split(/\s+/).includes('visible');
   }
 
   async configureSettings(config: {

--- a/tests/e2e/pages/SettingsPage.ts
+++ b/tests/e2e/pages/SettingsPage.ts
@@ -19,6 +19,9 @@ export class SettingsPage extends BasePage {
   readonly saveSettingsBtn: Locator;
   readonly cancelSettingsBtn: Locator;
   readonly modelInfoBtn: Locator;
+  readonly aiRefinementEnabledCheckbox: Locator;
+  readonly ollamaEndpointInput: Locator;
+  readonly ollamaTimeoutInput: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -33,6 +36,9 @@ export class SettingsPage extends BasePage {
     this.saveSettingsBtn = page.locator('#save-settings-btn');
     this.cancelSettingsBtn = page.locator('#cancel-settings-btn');
     this.modelInfoBtn = page.locator('#model-info-btn');
+    this.aiRefinementEnabledCheckbox = page.locator('#ai-refinement-enabled-checkbox');
+    this.ollamaEndpointInput = page.locator('#ollama-endpoint');
+    this.ollamaTimeoutInput = page.locator('#ollama-timeout');
   }
 
   async openSettings() {

--- a/tests/e2e/tests/settings-persistence.e2e.spec.ts
+++ b/tests/e2e/tests/settings-persistence.e2e.spec.ts
@@ -1,0 +1,281 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * E2E tests guarding the Settings panel against state-loading regressions.
+ *
+ * The renderer is served at localhost:3000 with no Electron IPC available, so
+ * we install a stateful mock of `window.electronAPI` via `addInitScript` and
+ * drive the real SettingsController against it.
+ *
+ * The motivating bug: `loadAIRefinementSettings` used to read
+ * `aiSettings.enabled` directly from the IPC response, but the handler
+ * returns `{ success, settings }`. The checkbox therefore loaded as
+ * unchecked every time, silently disabling AI Refinement on the next save.
+ */
+
+type ConfigState = {
+  whisper: {
+    defaultModel: string;
+    defaultLanguage: string;
+    defaultThreads: number;
+    translate: boolean;
+    useInitialPrompt: boolean;
+    initialPrompt: string;
+    useGpu: boolean;
+    flashAttn: boolean;
+    gpuDevice: number;
+    availableModels: { name: string; size: string; description: string }[];
+  };
+  aiRefinement: {
+    enabled: boolean;
+    endpoint: string;
+    model: string;
+    timeoutSeconds: number;
+    defaultTemplateId: string | null;
+  };
+  meetingNotes: {
+    defaultProvider: string;
+    claudeModel: string;
+    cliTimeoutSeconds: number;
+  };
+};
+
+const DEFAULT_STATE: ConfigState = {
+  whisper: {
+    defaultModel: 'base',
+    defaultLanguage: 'en',
+    defaultThreads: 4,
+    translate: false,
+    useInitialPrompt: false,
+    initialPrompt: '',
+    useGpu: false,
+    flashAttn: false,
+    gpuDevice: 0,
+    availableModels: [
+      { name: 'tiny', size: '39M', description: 'Tiny model' },
+      { name: 'base', size: '74M', description: 'Base model' }
+    ]
+  },
+  aiRefinement: {
+    enabled: true,
+    endpoint: 'http://localhost:11434',
+    model: 'gemma3:12b',
+    timeoutSeconds: 300,
+    defaultTemplateId: null
+  },
+  meetingNotes: {
+    defaultProvider: 'claude',
+    claudeModel: 'claude-sonnet-4-20250514',
+    cliTimeoutSeconds: 600
+  }
+};
+
+async function installElectronApiMock(page: Page, initial: ConfigState) {
+  await page.addInitScript((state) => {
+    // Stateful in-page mock of the Electron IPC bridge.
+    const w = window as unknown as {
+      __mockState: ConfigState;
+      __mockCalls: { name: string; args: unknown[] }[];
+      electronAPI: Record<string, unknown>;
+    };
+    w.__mockState = JSON.parse(JSON.stringify(state));
+    w.__mockCalls = [];
+    const record = (name: string, args: unknown[]) => {
+      w.__mockCalls.push({ name, args });
+    };
+    w.electronAPI = {
+      getConfig: () => {
+        record('getConfig', []);
+        const s = w.__mockState;
+        return Promise.resolve({
+          model: s.whisper.defaultModel,
+          language: s.whisper.defaultLanguage,
+          threads: s.whisper.defaultThreads,
+          translate: s.whisper.translate,
+          useInitialPrompt: s.whisper.useInitialPrompt,
+          initialPrompt: s.whisper.initialPrompt,
+          useGpu: s.whisper.useGpu,
+          flashAttn: s.whisper.flashAttn,
+          gpuDevice: s.whisper.gpuDevice,
+          whisper: { availableModels: s.whisper.availableModels }
+        });
+      },
+      setConfig: (settings: Record<string, unknown>) => {
+        record('setConfig', [settings]);
+        Object.assign(w.__mockState.whisper, {
+          defaultModel: settings.model ?? w.__mockState.whisper.defaultModel,
+          defaultLanguage: settings.language ?? w.__mockState.whisper.defaultLanguage,
+          defaultThreads: settings.threads ?? w.__mockState.whisper.defaultThreads,
+          translate: settings.translate ?? w.__mockState.whisper.translate,
+          useInitialPrompt: settings.useInitialPrompt ?? w.__mockState.whisper.useInitialPrompt,
+          initialPrompt: settings.initialPrompt ?? w.__mockState.whisper.initialPrompt,
+          useGpu: settings.useGpu ?? w.__mockState.whisper.useGpu,
+          flashAttn: settings.flashAttn ?? w.__mockState.whisper.flashAttn,
+          gpuDevice: settings.gpuDevice ?? w.__mockState.whisper.gpuDevice
+        });
+        return Promise.resolve({ success: true });
+      },
+      // Match the real refinementHandlers contract: { success, settings }.
+      getAIRefinementSettings: () => {
+        record('getAIRefinementSettings', []);
+        return Promise.resolve({
+          success: true,
+          settings: { ...w.__mockState.aiRefinement }
+        });
+      },
+      saveAIRefinementSettings: (settings: Record<string, unknown>) => {
+        record('saveAIRefinementSettings', [settings]);
+        Object.assign(w.__mockState.aiRefinement, settings);
+        return Promise.resolve({
+          success: true,
+          changed: true,
+          settings: { ...w.__mockState.aiRefinement }
+        });
+      },
+      getOllamaModels: () => {
+        record('getOllamaModels', []);
+        return Promise.resolve({
+          success: true,
+          models: [{ name: 'gemma3:12b', size: '7GB' }]
+        });
+      },
+      testOllamaConnection: () => Promise.resolve({ success: true, message: 'ok' }),
+      testWhisper: () => Promise.resolve({
+        success: true,
+        message: 'ok',
+        details: { availableModels: w.__mockState.whisper.availableModels }
+      }),
+      detectGpuBackend: () => Promise.resolve({
+        success: true,
+        expectedBackend: 'cpu',
+        platform: 'linux'
+      }),
+      debugAIRefinementSettings: () => Promise.resolve({
+        success: true,
+        configSettings: w.__mockState.aiRefinement,
+        ollamaSettings: {},
+        ollamaEnabled: w.__mockState.aiRefinement.enabled
+      }),
+      meetingNotes: {
+        getConfig: () => Promise.resolve({
+          success: true,
+          config: { ...w.__mockState.meetingNotes }
+        }),
+        saveConfig: (payload: { settings: Record<string, unknown> }) => {
+          record('meetingNotes.saveConfig', [payload]);
+          Object.assign(w.__mockState.meetingNotes, payload.settings);
+          return Promise.resolve({ success: true });
+        },
+        getTemplates: () => Promise.resolve({ success: true, templates: [] })
+      },
+      onTranscriptionProgress: () => {},
+      onRecordingUpdate: () => {},
+      onModelDownloadProgress: () => {},
+      onRefinementProgress: () => {},
+      onRefinementStream: () => {},
+      removeAllListeners: () => {}
+    };
+  }, initial);
+}
+
+async function openSettingsPanel(page: Page) {
+  await page.locator('#settings-btn').click();
+  await expect(page.locator('#settings-header')).toHaveClass(/visible/);
+  // Wait for loadSettings() to populate the AI refinement section.
+  await expect(page.locator('#ai-refinement-enabled-checkbox')).toBeVisible();
+}
+
+async function closeSettingsPanel(page: Page) {
+  await page.locator('#cancel-settings-btn').click();
+  await expect(page.locator('#settings-header')).not.toHaveClass(/visible/);
+}
+
+async function saveSettingsPanel(page: Page) {
+  await page.locator('#save-settings-btn').click();
+  await expect(page.locator('#settings-header')).not.toHaveClass(/visible/);
+}
+
+async function getMockCalls(page: Page) {
+  return page.evaluate(() =>
+    (window as unknown as { __mockCalls: { name: string; args: unknown[] }[] }).__mockCalls
+  );
+}
+
+async function getMockState(page: Page) {
+  return page.evaluate(() =>
+    (window as unknown as { __mockState: ConfigState }).__mockState
+  );
+}
+
+test.describe('Settings panel — AI Refinement persistence', () => {
+  test('checkbox reflects saved enabled=true on open', async ({ page }) => {
+    await installElectronApiMock(page, DEFAULT_STATE);
+    await page.goto('/');
+
+    await openSettingsPanel(page);
+
+    await expect(page.locator('#ai-refinement-enabled-checkbox')).toBeChecked();
+  });
+
+  test('checkbox reflects saved enabled=false on open', async ({ page }) => {
+    const state: ConfigState = JSON.parse(JSON.stringify(DEFAULT_STATE));
+    state.aiRefinement.enabled = false;
+    await installElectronApiMock(page, state);
+    await page.goto('/');
+
+    await openSettingsPanel(page);
+
+    await expect(page.locator('#ai-refinement-enabled-checkbox')).not.toBeChecked();
+  });
+
+  test('saving unrelated changes (language) preserves enabled=true', async ({ page }) => {
+    await installElectronApiMock(page, DEFAULT_STATE);
+    await page.goto('/');
+
+    await openSettingsPanel(page);
+    await expect(page.locator('#ai-refinement-enabled-checkbox')).toBeChecked();
+
+    // Change language only — the AI Refinement checkbox must be left alone.
+    await page.locator('#language-select').selectOption('es');
+    await saveSettingsPanel(page);
+
+    const calls = await getMockCalls(page);
+    const saveCall = calls.find(c => c.name === 'saveAIRefinementSettings');
+    expect(saveCall).toBeTruthy();
+    expect((saveCall!.args[0] as { enabled: boolean }).enabled).toBe(true);
+
+    const state = await getMockState(page);
+    expect(state.aiRefinement.enabled).toBe(true);
+
+    // Re-open: checkbox should still be checked.
+    await openSettingsPanel(page);
+    await expect(page.locator('#ai-refinement-enabled-checkbox')).toBeChecked();
+  });
+
+  test('checkbox state survives close/reopen without saving', async ({ page }) => {
+    await installElectronApiMock(page, DEFAULT_STATE);
+    await page.goto('/');
+
+    await openSettingsPanel(page);
+    await expect(page.locator('#ai-refinement-enabled-checkbox')).toBeChecked();
+    await closeSettingsPanel(page);
+
+    await openSettingsPanel(page);
+    await expect(page.locator('#ai-refinement-enabled-checkbox')).toBeChecked();
+  });
+
+  test('toggling the checkbox off and saving persists enabled=false', async ({ page }) => {
+    await installElectronApiMock(page, DEFAULT_STATE);
+    await page.goto('/');
+
+    await openSettingsPanel(page);
+    await page.locator('#ai-refinement-enabled-checkbox').uncheck();
+    await saveSettingsPanel(page);
+
+    const state = await getMockState(page);
+    expect(state.aiRefinement.enabled).toBe(false);
+
+    await openSettingsPanel(page);
+    await expect(page.locator('#ai-refinement-enabled-checkbox')).not.toBeChecked();
+  });
+});

--- a/tests/e2e/tests/settings-persistence.e2e.spec.ts
+++ b/tests/e2e/tests/settings-persistence.e2e.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
+import { SettingsPage } from '../pages';
 
 /**
  * E2E tests guarding the Settings panel against state-loading regressions.
@@ -178,23 +179,6 @@ async function installElectronApiMock(page: Page, initial: ConfigState) {
   }, initial);
 }
 
-async function openSettingsPanel(page: Page) {
-  await page.locator('#settings-btn').click();
-  await expect(page.locator('#settings-header')).toHaveClass(/visible/);
-  // Wait for loadSettings() to populate the AI refinement section.
-  await expect(page.locator('#ai-refinement-enabled-checkbox')).toBeVisible();
-}
-
-async function closeSettingsPanel(page: Page) {
-  await page.locator('#cancel-settings-btn').click();
-  await expect(page.locator('#settings-header')).not.toHaveClass(/visible/);
-}
-
-async function saveSettingsPanel(page: Page) {
-  await page.locator('#save-settings-btn').click();
-  await expect(page.locator('#settings-header')).not.toHaveClass(/visible/);
-}
-
 async function getMockCalls(page: Page) {
   return page.evaluate(() =>
     (window as unknown as { __mockCalls: { name: string; args: unknown[] }[] }).__mockCalls
@@ -207,37 +191,44 @@ async function getMockState(page: Page) {
   );
 }
 
+// Local helper: install mock, navigate, and return a SettingsPage object.
+// We can't use the shared `settingsPage` fixture because it navigates before
+// `addInitScript` would have a chance to install the IPC mock.
+async function bootSettings(page: Page, state: ConfigState = DEFAULT_STATE) {
+  await installElectronApiMock(page, state);
+  const settingsPage = new SettingsPage(page);
+  await settingsPage.goto();
+  return settingsPage;
+}
+
 test.describe('Settings panel — AI Refinement persistence', () => {
   test('checkbox reflects saved enabled=true on open', async ({ page }) => {
-    await installElectronApiMock(page, DEFAULT_STATE);
-    await page.goto('/');
+    const settingsPage = await bootSettings(page);
 
-    await openSettingsPanel(page);
+    await settingsPage.openSettings();
 
-    await expect(page.locator('#ai-refinement-enabled-checkbox')).toBeChecked();
+    await expect(settingsPage.aiRefinementEnabledCheckbox).toBeChecked();
   });
 
   test('checkbox reflects saved enabled=false on open', async ({ page }) => {
     const state: ConfigState = JSON.parse(JSON.stringify(DEFAULT_STATE));
     state.aiRefinement.enabled = false;
-    await installElectronApiMock(page, state);
-    await page.goto('/');
+    const settingsPage = await bootSettings(page, state);
 
-    await openSettingsPanel(page);
+    await settingsPage.openSettings();
 
-    await expect(page.locator('#ai-refinement-enabled-checkbox')).not.toBeChecked();
+    await expect(settingsPage.aiRefinementEnabledCheckbox).not.toBeChecked();
   });
 
   test('saving unrelated changes (language) preserves enabled=true', async ({ page }) => {
-    await installElectronApiMock(page, DEFAULT_STATE);
-    await page.goto('/');
+    const settingsPage = await bootSettings(page);
 
-    await openSettingsPanel(page);
-    await expect(page.locator('#ai-refinement-enabled-checkbox')).toBeChecked();
+    await settingsPage.openSettings();
+    await expect(settingsPage.aiRefinementEnabledCheckbox).toBeChecked();
 
     // Change language only — the AI Refinement checkbox must be left alone.
-    await page.locator('#language-select').selectOption('es');
-    await saveSettingsPanel(page);
+    await settingsPage.configureSettings({ language: 'es' });
+    await settingsPage.saveSettings();
 
     const calls = await getMockCalls(page);
     const saveCall = calls.find(c => c.name === 'saveAIRefinementSettings');
@@ -248,34 +239,33 @@ test.describe('Settings panel — AI Refinement persistence', () => {
     expect(state.aiRefinement.enabled).toBe(true);
 
     // Re-open: checkbox should still be checked.
-    await openSettingsPanel(page);
-    await expect(page.locator('#ai-refinement-enabled-checkbox')).toBeChecked();
+    await settingsPage.openSettings();
+    await expect(settingsPage.aiRefinementEnabledCheckbox).toBeChecked();
   });
 
   test('checkbox state survives close/reopen without saving', async ({ page }) => {
-    await installElectronApiMock(page, DEFAULT_STATE);
-    await page.goto('/');
+    const settingsPage = await bootSettings(page);
 
-    await openSettingsPanel(page);
-    await expect(page.locator('#ai-refinement-enabled-checkbox')).toBeChecked();
-    await closeSettingsPanel(page);
+    await settingsPage.openSettings();
+    await expect(settingsPage.aiRefinementEnabledCheckbox).toBeChecked();
+    await settingsPage.cancelSettings();
 
-    await openSettingsPanel(page);
-    await expect(page.locator('#ai-refinement-enabled-checkbox')).toBeChecked();
+    await settingsPage.openSettings();
+    await expect(settingsPage.aiRefinementEnabledCheckbox).toBeChecked();
   });
 
   test('toggling the checkbox off and saving persists enabled=false', async ({ page }) => {
-    await installElectronApiMock(page, DEFAULT_STATE);
-    await page.goto('/');
+    const settingsPage = await bootSettings(page);
 
-    await openSettingsPanel(page);
-    await page.locator('#ai-refinement-enabled-checkbox').uncheck();
-    await saveSettingsPanel(page);
+    await settingsPage.openSettings();
+    // The styled-checkbox is opacity:0; toggle via the underlying input.
+    await settingsPage.aiRefinementEnabledCheckbox.setChecked(false, { force: true });
+    await settingsPage.saveSettings();
 
     const state = await getMockState(page);
     expect(state.aiRefinement.enabled).toBe(false);
 
-    await openSettingsPanel(page);
-    await expect(page.locator('#ai-refinement-enabled-checkbox')).not.toBeChecked();
+    await settingsPage.openSettings();
+    await expect(settingsPage.aiRefinementEnabledCheckbox).not.toBeChecked();
   });
 });

--- a/tests/unit/renderer/settingsController.test.js
+++ b/tests/unit/renderer/settingsController.test.js
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for SettingsController — focused on AI Refinement load/save
+ * to prevent regressions like the "Enable AI Refinement" checkbox always
+ * loading as unchecked because the renderer reads the IPC wrapper at the
+ * wrong nesting level.
+ */
+
+const { JSDOM } = require('jsdom');
+const fs = require('fs');
+const path = require('path');
+
+describe('SettingsController – AI Refinement persistence', () => {
+    let SettingsController;
+    let controller;
+    let statusController;
+    let appState;
+    let dom;
+    let aiState;
+
+    beforeEach(() => {
+        const htmlPath = path.join(__dirname, '../../../src/renderer/index.html');
+        const html = fs.readFileSync(htmlPath, 'utf-8');
+        dom = new JSDOM(html, { url: 'http://localhost' });
+        global.window = dom.window;
+        global.document = dom.window.document;
+        global.HTMLElement = dom.window.HTMLElement;
+        global.Element = dom.window.Element;
+        global.Node = dom.window.Node;
+        global.navigator = dom.window.navigator;
+
+        aiState = {
+            enabled: true,
+            endpoint: 'http://localhost:11434',
+            model: 'gemma3:12b',
+            timeoutSeconds: 300,
+            defaultTemplateId: null
+        };
+
+        // Match the real refinementHandlers contract: { success, settings }.
+        global.window.electronAPI = {
+            getConfig: jest.fn(() => Promise.resolve({
+                model: 'base',
+                language: 'en',
+                threads: 4,
+                whisper: { availableModels: [] }
+            })),
+            setConfig: jest.fn(() => Promise.resolve({ success: true })),
+            testWhisper: jest.fn(() => Promise.resolve({ success: true, details: {} })),
+            detectGpuBackend: jest.fn(() => Promise.resolve({
+                success: true,
+                expectedBackend: 'cpu',
+                platform: 'linux'
+            })),
+            getAIRefinementSettings: jest.fn(() => Promise.resolve({
+                success: true,
+                settings: { ...aiState }
+            })),
+            saveAIRefinementSettings: jest.fn((partial) => {
+                Object.assign(aiState, partial);
+                return Promise.resolve({
+                    success: true,
+                    changed: true,
+                    settings: { ...aiState }
+                });
+            }),
+            getOllamaModels: jest.fn(() => Promise.resolve({
+                success: true,
+                models: [{ name: 'gemma3:12b', size: '7GB' }]
+            })),
+            testOllamaConnection: jest.fn(() => Promise.resolve({ success: true })),
+            debugAIRefinementSettings: jest.fn(() => Promise.resolve({ success: true })),
+            meetingNotes: {
+                getConfig: jest.fn(() => Promise.resolve({ success: true, config: {} })),
+                saveConfig: jest.fn(() => Promise.resolve({ success: true })),
+                getTemplates: jest.fn(() => Promise.resolve({ success: true, templates: [] }))
+            }
+        };
+
+        statusController = {
+            updateStatus: jest.fn(),
+            showError: jest.fn()
+        };
+        appState = {};
+
+        // Import after globals are wired up.
+        jest.isolateModules(() => {
+            // eslint-disable-next-line global-require
+            ({ SettingsController } = require('../../../src/renderer/controllers/SettingsController.js'));
+        });
+        controller = new SettingsController(appState, statusController);
+    });
+
+    afterEach(() => {
+        dom.window.close();
+        delete global.window;
+        delete global.document;
+    });
+
+    test('loads enabled=true from { success, settings } wrapper into the checkbox', async () => {
+        await controller.loadAIRefinementSettings();
+
+        const checkbox = document.getElementById('ai-refinement-enabled-checkbox');
+        expect(checkbox.checked).toBe(true);
+    });
+
+    test('loads enabled=false from { success, settings } wrapper into the checkbox', async () => {
+        aiState.enabled = false;
+        await controller.loadAIRefinementSettings();
+
+        const checkbox = document.getElementById('ai-refinement-enabled-checkbox');
+        expect(checkbox.checked).toBe(false);
+    });
+
+    test('loads endpoint, timeout, and model from the wrapper', async () => {
+        aiState.endpoint = 'http://example.test:9999';
+        aiState.timeoutSeconds = 120;
+        await controller.loadAIRefinementSettings();
+
+        expect(document.getElementById('ollama-endpoint').value).toBe('http://example.test:9999');
+        expect(document.getElementById('ollama-timeout').value).toBe('120');
+        expect(document.getElementById('ollama-model-select').value).toBe('gemma3:12b');
+    });
+
+    test('saveAIRefinementSettings preserves enabled=true after a load/save cycle', async () => {
+        await controller.loadAIRefinementSettings();
+        await controller.saveAIRefinementSettings();
+
+        const savedWith = global.window.electronAPI.saveAIRefinementSettings.mock.calls.at(-1)[0];
+        expect(savedWith.enabled).toBe(true);
+        expect(aiState.enabled).toBe(true);
+    });
+
+    test('also works if the IPC layer ever returns the bare settings object', async () => {
+        // Defensive: tolerate either shape.
+        global.window.electronAPI.getAIRefinementSettings = jest.fn(() => Promise.resolve({
+            enabled: true,
+            endpoint: 'http://localhost:11434',
+            model: 'gemma3:12b',
+            timeoutSeconds: 300
+        }));
+
+        await controller.loadAIRefinementSettings();
+
+        expect(document.getElementById('ai-refinement-enabled-checkbox').checked).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

Follow-up to PR #35. Users still saw the **Enable AI Refinement** checkbox load as unchecked locally even after the fix shipped — because their stale `src/renderer/dist/` from a prior `npm run build:renderer` was being served by the dev server in place of `src/renderer/`.

`scripts/start-renderer.js` had a comment promising "Prefer serving from src during development" but the implementation auto-preferred `dist` whenever it existed. This change makes the code match the comment.

## What changed

- `scripts/start-renderer.js` — `npm run start:renderer` now always serves from `src/renderer/`. The built bundle is only used when `USE_DIST=1` is explicitly set (for prod-like testing).

## Test plan

- [x] With a stale `src/renderer/dist` present, `npm run start:renderer` now serves the source-level `SettingsController.js` (verified: the file at `localhost:3000/controllers/SettingsController.js` matches `src/renderer/...`).
- [x] `USE_DIST=1 npm run start:renderer` still serves from `dist/` when an index is present.
- [x] Falls back to src if `USE_DIST=1` is set but no dist exists.