### PR TITLE
Add Language Settings to Recording screen

### DIFF
--- a/src/renderer/controllers/RecordingController.js
+++ b/src/renderer/controllers/RecordingController.js
@@ -256,10 +256,11 @@ export class RecordingController {
 
         // ---- Language Settings (mirror of settings panel) ----
         EventHandler.addListener('#record-language-select', 'change', EventHandler.createAsyncHandler(async (e) => {
-            const language = String(e.target.value || '');
+            const uiValue = String(e.target.value || '');
+            const language = uiValue === '' ? 'auto' : uiValue;
             try { await window.electronAPI.setConfig({ language }); } catch (err) { console.warn('Failed to persist language:', err?.message); }
             const settingsEl = UIHelpers.getElementById('language-select');
-            if (settingsEl) settingsEl.value = language;
+            if (settingsEl) settingsEl.value = uiValue;
         }));
 
         EventHandler.addListener('#record-translate-checkbox', 'change', EventHandler.createAsyncHandler(async (e) => {
@@ -298,7 +299,10 @@ export class RecordingController {
             await this._updateCaptureModeUI(captureMode);
 
             const elLang = UIHelpers.getElementById('record-language-select');
-            if (elLang) elLang.value = cfg && cfg.language ? cfg.language : '';
+            if (elLang) {
+                const persisted = cfg && cfg.language;
+                elLang.value = (!persisted || persisted === 'auto') ? '' : persisted;
+            }
             const elTranslate = UIHelpers.getElementById('record-translate-checkbox');
             if (elTranslate) elTranslate.checked = !!(cfg && cfg.translate);
         } catch (e) {

--- a/src/renderer/controllers/RecordingController.js
+++ b/src/renderer/controllers/RecordingController.js
@@ -255,34 +255,58 @@ export class RecordingController {
         }));
 
         // ---- Language Settings (mirror of settings panel) ----
+        // Cache the last persisted UI values so we can roll back on failure.
+        this._lastPersistedLanguageUi = '';
+        this._lastPersistedTranslate = false;
+
         EventHandler.addListener('#record-language-select', 'change', EventHandler.createAsyncHandler(async (e) => {
+            const previousUi = this._lastPersistedLanguageUi;
             const uiValue = String(e.target.value || '');
             const language = uiValue === '' ? 'auto' : uiValue;
             let saved = false;
+            let errMsg = null;
             try {
                 const result = await window.electronAPI.setConfig({ language });
                 saved = !result || result.success !== false;
+                if (!saved) errMsg = (result && result.message) || 'Failed to save language';
             } catch (err) {
-                console.warn('Failed to persist language:', err?.message);
+                errMsg = err?.message || 'Failed to save language';
+                console.warn('Failed to persist language:', errMsg);
             }
             if (saved) {
+                this._lastPersistedLanguageUi = uiValue;
                 const settingsEl = UIHelpers.getElementById('language-select');
                 if (settingsEl) settingsEl.value = uiValue;
+            } else {
+                e.target.value = previousUi;
+                if (this.statusController && this.statusController.showError) {
+                    this.statusController.showError(errMsg);
+                }
             }
         }));
 
         EventHandler.addListener('#record-translate-checkbox', 'change', EventHandler.createAsyncHandler(async (e) => {
+            const previous = this._lastPersistedTranslate;
             const translate = !!e.target.checked;
             let saved = false;
+            let errMsg = null;
             try {
                 const result = await window.electronAPI.setConfig({ translate });
                 saved = !result || result.success !== false;
+                if (!saved) errMsg = (result && result.message) || 'Failed to save translate option';
             } catch (err) {
-                console.warn('Failed to persist translate:', err?.message);
+                errMsg = err?.message || 'Failed to save translate option';
+                console.warn('Failed to persist translate:', errMsg);
             }
             if (saved) {
+                this._lastPersistedTranslate = translate;
                 const settingsEl = UIHelpers.getElementById('translate-checkbox');
                 if (settingsEl) settingsEl.checked = translate;
+            } else {
+                e.target.checked = previous;
+                if (this.statusController && this.statusController.showError) {
+                    this.statusController.showError(errMsg);
+                }
             }
         }));
 
@@ -314,13 +338,15 @@ export class RecordingController {
             if (elCaptureMode) elCaptureMode.value = captureMode;
             await this._updateCaptureModeUI(captureMode);
 
+            const persistedLang = cfg && cfg.language;
+            const langUi = (!persistedLang || persistedLang === 'auto') ? '' : persistedLang;
+            const persistedTranslate = !!(cfg && cfg.translate);
+            this._lastPersistedLanguageUi = langUi;
+            this._lastPersistedTranslate = persistedTranslate;
             const elLang = UIHelpers.getElementById('record-language-select');
-            if (elLang) {
-                const persisted = cfg && cfg.language;
-                elLang.value = (!persisted || persisted === 'auto') ? '' : persisted;
-            }
+            if (elLang) elLang.value = langUi;
             const elTranslate = UIHelpers.getElementById('record-translate-checkbox');
-            if (elTranslate) elTranslate.checked = !!(cfg && cfg.translate);
+            if (elTranslate) elTranslate.checked = persistedTranslate;
         } catch (e) {
             console.warn('Failed to load VAD settings into UI:', e?.message);
         }

--- a/src/renderer/controllers/RecordingController.js
+++ b/src/renderer/controllers/RecordingController.js
@@ -258,16 +258,32 @@ export class RecordingController {
         EventHandler.addListener('#record-language-select', 'change', EventHandler.createAsyncHandler(async (e) => {
             const uiValue = String(e.target.value || '');
             const language = uiValue === '' ? 'auto' : uiValue;
-            try { await window.electronAPI.setConfig({ language }); } catch (err) { console.warn('Failed to persist language:', err?.message); }
-            const settingsEl = UIHelpers.getElementById('language-select');
-            if (settingsEl) settingsEl.value = uiValue;
+            let saved = false;
+            try {
+                const result = await window.electronAPI.setConfig({ language });
+                saved = !result || result.success !== false;
+            } catch (err) {
+                console.warn('Failed to persist language:', err?.message);
+            }
+            if (saved) {
+                const settingsEl = UIHelpers.getElementById('language-select');
+                if (settingsEl) settingsEl.value = uiValue;
+            }
         }));
 
         EventHandler.addListener('#record-translate-checkbox', 'change', EventHandler.createAsyncHandler(async (e) => {
             const translate = !!e.target.checked;
-            try { await window.electronAPI.setConfig({ translate }); } catch (err) { console.warn('Failed to persist translate:', err?.message); }
-            const settingsEl = UIHelpers.getElementById('translate-checkbox');
-            if (settingsEl) settingsEl.checked = translate;
+            let saved = false;
+            try {
+                const result = await window.electronAPI.setConfig({ translate });
+                saved = !result || result.success !== false;
+            } catch (err) {
+                console.warn('Failed to persist translate:', err?.message);
+            }
+            if (saved) {
+                const settingsEl = UIHelpers.getElementById('translate-checkbox');
+                if (settingsEl) settingsEl.checked = translate;
+            }
         }));
 
         // Initialize VAD settings UI from persisted config

--- a/src/renderer/controllers/RecordingController.js
+++ b/src/renderer/controllers/RecordingController.js
@@ -255,7 +255,12 @@ export class RecordingController {
         }));
 
         // ---- Language Settings (mirror of settings panel) ----
+        // Per-field request sequence to ignore results from stale in-flight saves.
+        this._languageSaveSeq = 0;
+        this._translateSaveSeq = 0;
+
         EventHandler.addListener('#record-language-select', 'change', EventHandler.createAsyncHandler(async (e) => {
+            const seq = ++this._languageSaveSeq;
             const uiValue = String(e.target.value || '');
             const language = uiValue === '' ? 'auto' : uiValue;
             let saved = false;
@@ -268,11 +273,17 @@ export class RecordingController {
                 errMsg = err?.message || 'Failed to save language';
                 console.warn('Failed to persist language:', errMsg);
             }
+            // Ignore stale results — only the latest request may touch the UI.
+            if (seq !== this._languageSaveSeq) return;
             if (saved) {
+                // Reassert the resolved value on both controls so an earlier
+                // failed rollback cannot leave the Recording control stale.
+                if (e.target) e.target.value = uiValue;
                 const settingsEl = UIHelpers.getElementById('language-select');
                 if (settingsEl) settingsEl.value = uiValue;
             } else {
                 await this._restoreLanguageUiFromConfig(e.target);
+                if (seq !== this._languageSaveSeq) return;
                 if (this.statusController && this.statusController.showError) {
                     this.statusController.showError(errMsg);
                 }
@@ -280,6 +291,7 @@ export class RecordingController {
         }));
 
         EventHandler.addListener('#record-translate-checkbox', 'change', EventHandler.createAsyncHandler(async (e) => {
+            const seq = ++this._translateSaveSeq;
             const translate = !!e.target.checked;
             let saved = false;
             let errMsg = null;
@@ -291,11 +303,14 @@ export class RecordingController {
                 errMsg = err?.message || 'Failed to save translate option';
                 console.warn('Failed to persist translate:', errMsg);
             }
+            if (seq !== this._translateSaveSeq) return;
             if (saved) {
+                if (e.target) e.target.checked = translate;
                 const settingsEl = UIHelpers.getElementById('translate-checkbox');
                 if (settingsEl) settingsEl.checked = translate;
             } else {
                 await this._restoreTranslateUiFromConfig(e.target);
+                if (seq !== this._translateSaveSeq) return;
                 if (this.statusController && this.statusController.showError) {
                     this.statusController.showError(errMsg);
                 }

--- a/src/renderer/controllers/RecordingController.js
+++ b/src/renderer/controllers/RecordingController.js
@@ -254,6 +254,21 @@ export class RecordingController {
             this._applyVADRuntime({ engine });
         }));
 
+        // ---- Language Settings (mirror of settings panel) ----
+        EventHandler.addListener('#record-language-select', 'change', EventHandler.createAsyncHandler(async (e) => {
+            const language = String(e.target.value || '');
+            try { await window.electronAPI.setConfig({ language }); } catch (err) { console.warn('Failed to persist language:', err?.message); }
+            const settingsEl = UIHelpers.getElementById('language-select');
+            if (settingsEl) settingsEl.value = language;
+        }));
+
+        EventHandler.addListener('#record-translate-checkbox', 'change', EventHandler.createAsyncHandler(async (e) => {
+            const translate = !!e.target.checked;
+            try { await window.electronAPI.setConfig({ translate }); } catch (err) { console.warn('Failed to persist translate:', err?.message); }
+            const settingsEl = UIHelpers.getElementById('translate-checkbox');
+            if (settingsEl) settingsEl.checked = translate;
+        }));
+
         // Initialize VAD settings UI from persisted config
         this._loadVADSettingsIntoUI();
     }
@@ -281,6 +296,11 @@ export class RecordingController {
             const elCaptureMode = UIHelpers.getElementById('capture-mode-select');
             if (elCaptureMode) elCaptureMode.value = captureMode;
             await this._updateCaptureModeUI(captureMode);
+
+            const elLang = UIHelpers.getElementById('record-language-select');
+            if (elLang) elLang.value = cfg && cfg.language ? cfg.language : '';
+            const elTranslate = UIHelpers.getElementById('record-translate-checkbox');
+            if (elTranslate) elTranslate.checked = !!(cfg && cfg.translate);
         } catch (e) {
             console.warn('Failed to load VAD settings into UI:', e?.message);
         }

--- a/src/renderer/controllers/RecordingController.js
+++ b/src/renderer/controllers/RecordingController.js
@@ -255,12 +255,7 @@ export class RecordingController {
         }));
 
         // ---- Language Settings (mirror of settings panel) ----
-        // Cache the last persisted UI values so we can roll back on failure.
-        this._lastPersistedLanguageUi = '';
-        this._lastPersistedTranslate = false;
-
         EventHandler.addListener('#record-language-select', 'change', EventHandler.createAsyncHandler(async (e) => {
-            const previousUi = this._lastPersistedLanguageUi;
             const uiValue = String(e.target.value || '');
             const language = uiValue === '' ? 'auto' : uiValue;
             let saved = false;
@@ -274,11 +269,10 @@ export class RecordingController {
                 console.warn('Failed to persist language:', errMsg);
             }
             if (saved) {
-                this._lastPersistedLanguageUi = uiValue;
                 const settingsEl = UIHelpers.getElementById('language-select');
                 if (settingsEl) settingsEl.value = uiValue;
             } else {
-                e.target.value = previousUi;
+                await this._restoreLanguageUiFromConfig(e.target);
                 if (this.statusController && this.statusController.showError) {
                     this.statusController.showError(errMsg);
                 }
@@ -286,7 +280,6 @@ export class RecordingController {
         }));
 
         EventHandler.addListener('#record-translate-checkbox', 'change', EventHandler.createAsyncHandler(async (e) => {
-            const previous = this._lastPersistedTranslate;
             const translate = !!e.target.checked;
             let saved = false;
             let errMsg = null;
@@ -299,11 +292,10 @@ export class RecordingController {
                 console.warn('Failed to persist translate:', errMsg);
             }
             if (saved) {
-                this._lastPersistedTranslate = translate;
                 const settingsEl = UIHelpers.getElementById('translate-checkbox');
                 if (settingsEl) settingsEl.checked = translate;
             } else {
-                e.target.checked = previous;
+                await this._restoreTranslateUiFromConfig(e.target);
                 if (this.statusController && this.statusController.showError) {
                     this.statusController.showError(errMsg);
                 }
@@ -341,14 +333,46 @@ export class RecordingController {
             const persistedLang = cfg && cfg.language;
             const langUi = (!persistedLang || persistedLang === 'auto') ? '' : persistedLang;
             const persistedTranslate = !!(cfg && cfg.translate);
-            this._lastPersistedLanguageUi = langUi;
-            this._lastPersistedTranslate = persistedTranslate;
             const elLang = UIHelpers.getElementById('record-language-select');
             if (elLang) elLang.value = langUi;
             const elTranslate = UIHelpers.getElementById('record-translate-checkbox');
             if (elTranslate) elTranslate.checked = persistedTranslate;
         } catch (e) {
             console.warn('Failed to load VAD settings into UI:', e?.message);
+        }
+    }
+
+    /**
+     * Read the currently persisted language and write it back into the given
+     * Recording-screen select (and mirror into the Settings panel control).
+     * Used to roll back a failed save without relying on a local cache.
+     */
+    async _restoreLanguageUiFromConfig(targetEl) {
+        try {
+            const cfg = await window.electronAPI.getConfig();
+            const persisted = cfg && cfg.language;
+            const langUi = (!persisted || persisted === 'auto') ? '' : persisted;
+            if (targetEl) targetEl.value = langUi;
+            const settingsEl = UIHelpers.getElementById('language-select');
+            if (settingsEl) settingsEl.value = langUi;
+        } catch (err) {
+            console.warn('Failed to reload language from config:', err?.message);
+        }
+    }
+
+    /**
+     * Read the currently persisted translate flag and write it back into the
+     * given Recording-screen checkbox (and mirror into the Settings panel).
+     */
+    async _restoreTranslateUiFromConfig(targetEl) {
+        try {
+            const cfg = await window.electronAPI.getConfig();
+            const persisted = !!(cfg && cfg.translate);
+            if (targetEl) targetEl.checked = persisted;
+            const settingsEl = UIHelpers.getElementById('translate-checkbox');
+            if (settingsEl) settingsEl.checked = persisted;
+        } catch (err) {
+            console.warn('Failed to reload translate from config:', err?.message);
         }
     }
 

--- a/src/renderer/controllers/SettingsController.js
+++ b/src/renderer/controllers/SettingsController.js
@@ -164,11 +164,6 @@ export class SettingsController {
             const language = languageUi === '' ? 'auto' : languageUi;
             const threads = parseInt(UIHelpers.getValue('#threads-select'));
             const translate = UIHelpers.isChecked('#translate-checkbox');
-            // Mirror into Recording-screen copies to keep both UIs in sync
-            const recordLangEl = UIHelpers.getElementById('record-language-select');
-            if (recordLangEl) recordLangEl.value = languageUi;
-            const recordTranslateEl = UIHelpers.getElementById('record-translate-checkbox');
-            if (recordTranslateEl) recordTranslateEl.checked = translate;
             const useInitialPrompt = UIHelpers.isChecked('#use-initial-prompt-checkbox');
             const initialPrompt = UIHelpers.getValue('#initial-prompt');
             const useGpu = UIHelpers.isChecked('#use-gpu-checkbox');
@@ -213,6 +208,12 @@ export class SettingsController {
 
             // Save Meeting Notes settings
             await this.saveMeetingNotesSettings();
+
+            // Mirror into Recording-screen copies only after a successful save
+            const recordLangEl = UIHelpers.getElementById('record-language-select');
+            if (recordLangEl) recordLangEl.value = languageUi;
+            const recordTranslateEl = UIHelpers.getElementById('record-translate-checkbox');
+            if (recordTranslateEl) recordTranslateEl.checked = translate;
 
             this.closeSettings();
             this.statusController.updateStatus('Settings saved successfully');

--- a/src/renderer/controllers/SettingsController.js
+++ b/src/renderer/controllers/SettingsController.js
@@ -202,18 +202,20 @@ export class SettingsController {
                     return;
                 }
             }
-            
+
+            // Basic Whisper settings (including language/translate) are now
+            // persisted. Mirror into the Recording-screen copies immediately so
+            // they stay in sync even if later section saves fail.
+            const recordLangEl = UIHelpers.getElementById('record-language-select');
+            if (recordLangEl) recordLangEl.value = languageUi;
+            const recordTranslateEl = UIHelpers.getElementById('record-translate-checkbox');
+            if (recordTranslateEl) recordTranslateEl.checked = translate;
+
             // Save AI Refinement settings
             await this.saveAIRefinementSettings();
 
             // Save Meeting Notes settings
             await this.saveMeetingNotesSettings();
-
-            // Mirror into Recording-screen copies only after a successful save
-            const recordLangEl = UIHelpers.getElementById('record-language-select');
-            if (recordLangEl) recordLangEl.value = languageUi;
-            const recordTranslateEl = UIHelpers.getElementById('record-translate-checkbox');
-            if (recordTranslateEl) recordTranslateEl.checked = translate;
 
             this.closeSettings();
             this.statusController.updateStatus('Settings saved successfully');

--- a/src/renderer/controllers/SettingsController.js
+++ b/src/renderer/controllers/SettingsController.js
@@ -160,9 +160,15 @@ export class SettingsController {
             
             // Get basic Whisper settings
             const model = UIHelpers.getValue('#model-select');
-            const language = UIHelpers.getValue('#language-select');
+            const languageUi = UIHelpers.getValue('#language-select');
+            const language = languageUi === '' ? 'auto' : languageUi;
             const threads = parseInt(UIHelpers.getValue('#threads-select'));
             const translate = UIHelpers.isChecked('#translate-checkbox');
+            // Mirror into Recording-screen copies to keep both UIs in sync
+            const recordLangEl = UIHelpers.getElementById('record-language-select');
+            if (recordLangEl) recordLangEl.value = languageUi;
+            const recordTranslateEl = UIHelpers.getElementById('record-translate-checkbox');
+            if (recordTranslateEl) recordTranslateEl.checked = translate;
             const useInitialPrompt = UIHelpers.isChecked('#use-initial-prompt-checkbox');
             const initialPrompt = UIHelpers.getValue('#initial-prompt');
             const useGpu = UIHelpers.isChecked('#use-gpu-checkbox');
@@ -231,13 +237,16 @@ export class SettingsController {
                 this.updateModelDescription(settings.model);
             }
             if (settings.language) {
-                UIHelpers.setValue('#language-select', settings.language);
+                const langUi = settings.language === 'auto' ? '' : settings.language;
+                UIHelpers.setValue('#language-select', langUi);
+                UIHelpers.setValue('#record-language-select', langUi);
             }
             if (settings.threads) {
                 UIHelpers.setValue('#threads-select', settings.threads.toString());
             }
             if (settings.translate !== undefined) {
                 UIHelpers.setChecked('#translate-checkbox', settings.translate);
+                UIHelpers.setChecked('#record-translate-checkbox', settings.translate);
             }
             if (settings.useInitialPrompt !== undefined) {
                 UIHelpers.setChecked('#use-initial-prompt-checkbox', settings.useInitialPrompt);

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -399,6 +399,36 @@
                                         </select>
                                     </div>
                                 </div>
+
+                                <!-- Language Settings -->
+                                <div class="settings-card language-card">
+                                    <h4 class="settings-card-title">Language Settings</h4>
+
+                                    <div class="form-group">
+                                        <label for="record-language-select">Transcription Language</label>
+                                        <select id="record-language-select" class="form-control">
+                                            <option value="">Auto-detect language</option>
+                                            <option value="en">English</option>
+                                            <option value="es">Spanish</option>
+                                            <option value="fr">French</option>
+                                            <option value="de">German</option>
+                                            <option value="it">Italian</option>
+                                            <option value="pt">Portuguese</option>
+                                            <option value="ru">Russian</option>
+                                            <option value="ja">Japanese</option>
+                                            <option value="ko">Korean</option>
+                                            <option value="zh">Chinese</option>
+                                        </select>
+                                    </div>
+
+                                    <div class="form-group">
+                                        <div class="checkbox-container">
+                                            <input type="checkbox" id="record-translate-checkbox" class="styled-checkbox">
+                                            <label for="record-translate-checkbox">Translate to English</label>
+                                        </div>
+                                        <div class="form-text">Convert non-English audio to English text</div>
+                                    </div>
+                                </div>
                             </div>
 
                             <div class="record-controls">

--- a/tests/unit/renderer/recordingLanguageSettings.test.js
+++ b/tests/unit/renderer/recordingLanguageSettings.test.js
@@ -172,9 +172,11 @@ describe('Recording-screen Language Settings', () => {
         expect(document.getElementById('translate-checkbox').checked).toBe(true);
     });
 
-    test('Recording -> Settings: do NOT mirror when setConfig reports success:false', async () => {
-        global.window.electronAPI.setConfig.mockResolvedValue({ success: false });
-        buildRecordingController();
+    test('Recording -> Settings: do NOT mirror and roll back originating control when setConfig reports success:false', async () => {
+        global.window.electronAPI.getConfig.mockResolvedValue({ language: 'en', translate: false });
+        global.window.electronAPI.setConfig.mockResolvedValue({ success: false, message: 'no' });
+        const controller = buildRecordingController();
+        await controller._loadVADSettingsIntoUI();
 
         // Seed settings panel with a known value so we can detect drift.
         document.getElementById('language-select').value = 'en';
@@ -185,11 +187,15 @@ describe('Recording-screen Language Settings', () => {
         await new Promise((r) => setImmediate(r));
 
         expect(document.getElementById('language-select').value).toBe('en');
+        expect(document.getElementById('record-language-select').value).toBe('en');
+        expect(statusController.showError).toHaveBeenCalled();
     });
 
-    test('Recording -> Settings: do NOT mirror when setConfig throws', async () => {
+    test('Recording -> Settings: roll back originating control when setConfig throws', async () => {
+        global.window.electronAPI.getConfig.mockResolvedValue({ language: 'en', translate: false });
         global.window.electronAPI.setConfig.mockRejectedValue(new Error('boom'));
-        buildRecordingController();
+        const controller = buildRecordingController();
+        await controller._loadVADSettingsIntoUI();
 
         document.getElementById('translate-checkbox').checked = false;
 
@@ -199,6 +205,8 @@ describe('Recording-screen Language Settings', () => {
         await new Promise((r) => setImmediate(r));
 
         expect(document.getElementById('translate-checkbox').checked).toBe(false);
+        expect(document.getElementById('record-translate-checkbox').checked).toBe(false);
+        expect(statusController.showError).toHaveBeenCalled();
     });
 
     test('Settings panel save mirrors language/translate into Recording screen', async () => {
@@ -232,6 +240,24 @@ describe('Recording-screen Language Settings', () => {
             expect.objectContaining({ language: 'auto' })
         );
         expect(document.getElementById('record-language-select').value).toBe('');
+    });
+
+    test('Settings panel save mirrors language to Recording screen even if AI Refinement save fails', async () => {
+        global.window.electronAPI.saveAIRefinementSettings.mockRejectedValue(new Error('ai down'));
+        const controller = buildSettingsController();
+
+        document.getElementById('model-select').value = 'base';
+        document.getElementById('language-select').value = 'ko';
+        document.getElementById('threads-select').value = '4';
+        document.getElementById('translate-checkbox').checked = true;
+
+        await controller.saveSettings();
+
+        // Whisper settings (incl. language/translate) were already persisted
+        // before the AI Refinement save, so the Recording-screen copy must
+        // match the persisted state, not the prior stale UI state.
+        expect(document.getElementById('record-language-select').value).toBe('ko');
+        expect(document.getElementById('record-translate-checkbox').checked).toBe(true);
     });
 
     test('Settings panel save does NOT mirror to Recording screen when setConfig rejects', async () => {

--- a/tests/unit/renderer/recordingLanguageSettings.test.js
+++ b/tests/unit/renderer/recordingLanguageSettings.test.js
@@ -320,6 +320,39 @@ describe('Recording-screen Language Settings', () => {
         expect(document.getElementById('language-select').value).toBe('ko');
     });
 
+    test('overlapping Recording-screen saves: earlier failure must not leave the control stale after a later success', async () => {
+        global.window.electronAPI.getConfig.mockResolvedValue({ language: 'en', translate: false });
+        const controller = buildRecordingController();
+        await controller._loadVADSettingsIntoUI();
+
+        // Two pending setConfig calls: first fails (request A), second succeeds (request B).
+        let resolveA;
+        let resolveB;
+        global.window.electronAPI.setConfig
+            .mockImplementationOnce(() => new Promise((res) => { resolveA = res; }))
+            .mockImplementationOnce(() => new Promise((res) => { resolveB = res; }));
+
+        const recLang = document.getElementById('record-language-select');
+
+        // User changes to 'ja' (request A)
+        recLang.value = 'ja';
+        fireChange(recLang);
+        // User quickly changes to 'ko' (request B) before A resolves
+        recLang.value = 'ko';
+        fireChange(recLang);
+
+        // Request A fails first, then request B succeeds
+        resolveA({ success: false, message: 'no' });
+        resolveB({ success: true });
+
+        await new Promise((r) => setImmediate(r));
+        await new Promise((r) => setImmediate(r));
+
+        // Final state must match the latest successful request, not the rollback.
+        expect(recLang.value).toBe('ko');
+        expect(document.getElementById('language-select').value).toBe('ko');
+    });
+
     test('Settings panel load mirrors language/translate into Recording screen', async () => {
         global.window.electronAPI.getConfig.mockResolvedValue({
             model: 'base', language: 'it', threads: 4, translate: true

--- a/tests/unit/renderer/recordingLanguageSettings.test.js
+++ b/tests/unit/renderer/recordingLanguageSettings.test.js
@@ -1,0 +1,277 @@
+/**
+ * Unit tests for the Recording-screen Language Settings duplicate:
+ *  - `''` <-> `'auto'` mapping on save/load
+ *  - syncing from Recording screen to Settings panel
+ *  - syncing from Settings panel back to Recording screen
+ *  - failure/cancel paths must not desync UI from persisted config
+ */
+
+const { JSDOM } = require('jsdom');
+const fs = require('fs');
+const path = require('path');
+
+const HTML_PATH = path.join(__dirname, '../../../src/renderer/index.html');
+
+function setupDom() {
+    const html = fs.readFileSync(HTML_PATH, 'utf-8');
+    const dom = new JSDOM(html, { url: 'http://localhost' });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.HTMLElement = dom.window.HTMLElement;
+    global.Element = dom.window.Element;
+    global.Node = dom.window.Node;
+    global.navigator = dom.window.navigator;
+    // jsdom returns null from canvas.getContext by default; stub a 2d context.
+    dom.window.HTMLCanvasElement.prototype.getContext = () => ({
+        fillStyle: '', fillRect: () => {}, clearRect: () => {},
+        fillText: () => {}, font: '', textAlign: '', textBaseline: '',
+        beginPath: () => {}, moveTo: () => {}, lineTo: () => {}, stroke: () => {},
+        strokeStyle: '', lineWidth: 0, save: () => {}, restore: () => {},
+        translate: () => {}, scale: () => {},
+    });
+    return dom;
+}
+
+function teardownDom(dom) {
+    dom.window.close();
+    delete global.window;
+    delete global.document;
+    delete global.HTMLElement;
+    delete global.Element;
+    delete global.Node;
+    delete global.navigator;
+}
+
+function fireChange(el) {
+    el.dispatchEvent(new global.window.Event('change'));
+}
+
+describe('Recording-screen Language Settings', () => {
+    let dom;
+    let RecordingController;
+    let SettingsController;
+    let appState;
+    let statusController;
+    let tabController;
+
+    function buildRecordingController() {
+        return new RecordingController(appState, statusController, tabController);
+    }
+
+    function buildSettingsController() {
+        return new SettingsController(appState, statusController);
+    }
+
+    beforeEach(() => {
+        dom = setupDom();
+
+        global.window.electronAPI = {
+            getConfig: jest.fn().mockResolvedValue({}),
+            setConfig: jest.fn().mockResolvedValue({ success: true }),
+            testWhisper: jest.fn().mockResolvedValue({ success: true, details: {} }),
+            detectGpuBackend: jest.fn().mockResolvedValue({
+                success: true, expectedBackend: 'cpu', platform: 'linux'
+            }),
+            getAIRefinementSettings: jest.fn().mockResolvedValue({
+                success: true,
+                settings: { enabled: false, endpoint: '', model: '', timeoutSeconds: 300 }
+            }),
+            saveAIRefinementSettings: jest.fn().mockResolvedValue({ success: true }),
+            getOllamaModels: jest.fn().mockResolvedValue({ success: true, models: [] }),
+            testOllamaConnection: jest.fn().mockResolvedValue({ success: true }),
+            meetingNotes: {
+                getConfig: jest.fn().mockResolvedValue({ success: true, config: {} }),
+                saveConfig: jest.fn().mockResolvedValue({ success: true }),
+                getTemplates: jest.fn().mockResolvedValue({ success: true, templates: [] })
+            }
+        };
+
+        // Stub APIs that RecordingController might touch in init.
+        global.window.AudioContext = jest.fn();
+        global.window.MediaRecorder = jest.fn();
+        global.AudioContext = global.window.AudioContext;
+        global.MediaRecorder = global.window.MediaRecorder;
+
+        appState = {
+            subscribe: jest.fn(),
+            getRecordingState: jest.fn().mockReturnValue({}),
+            setRecordingState: jest.fn(),
+        };
+        statusController = {
+            updateStatus: jest.fn(),
+            showError: jest.fn(),
+        };
+        tabController = { switchTab: jest.fn() };
+
+        jest.isolateModules(() => {
+            // eslint-disable-next-line global-require
+            ({ RecordingController } = require('../../../src/renderer/controllers/RecordingController.js'));
+            // eslint-disable-next-line global-require
+            ({ SettingsController } = require('../../../src/renderer/controllers/SettingsController.js'));
+        });
+    });
+
+    afterEach(() => {
+        teardownDom(dom);
+        jest.clearAllMocks();
+    });
+
+    test('selecting Auto-detect persists language as "auto"', async () => {
+        buildRecordingController();
+
+        const select = document.getElementById('record-language-select');
+        select.value = '';
+        fireChange(select);
+        await new Promise((r) => setImmediate(r));
+
+        expect(global.window.electronAPI.setConfig).toHaveBeenCalledWith({ language: 'auto' });
+    });
+
+    test('selecting a specific language persists that language code', async () => {
+        buildRecordingController();
+
+        const select = document.getElementById('record-language-select');
+        select.value = 'fr';
+        fireChange(select);
+        await new Promise((r) => setImmediate(r));
+
+        expect(global.window.electronAPI.setConfig).toHaveBeenCalledWith({ language: 'fr' });
+    });
+
+    test('persisted "auto" loads as empty (Auto-detect) on Recording screen', async () => {
+        global.window.electronAPI.getConfig.mockResolvedValue({ language: 'auto', translate: false });
+        const controller = buildRecordingController();
+
+        await controller._loadVADSettingsIntoUI();
+
+        expect(document.getElementById('record-language-select').value).toBe('');
+    });
+
+    test('persisted language code loads into Recording screen as-is', async () => {
+        global.window.electronAPI.getConfig.mockResolvedValue({ language: 'de', translate: true });
+        const controller = buildRecordingController();
+
+        await controller._loadVADSettingsIntoUI();
+
+        expect(document.getElementById('record-language-select').value).toBe('de');
+        expect(document.getElementById('record-translate-checkbox').checked).toBe(true);
+    });
+
+    test('Recording -> Settings sync on successful save', async () => {
+        buildRecordingController();
+
+        const recLang = document.getElementById('record-language-select');
+        const recTranslate = document.getElementById('record-translate-checkbox');
+        recLang.value = 'es';
+        fireChange(recLang);
+        recTranslate.checked = true;
+        fireChange(recTranslate);
+        await new Promise((r) => setImmediate(r));
+
+        expect(document.getElementById('language-select').value).toBe('es');
+        expect(document.getElementById('translate-checkbox').checked).toBe(true);
+    });
+
+    test('Recording -> Settings: do NOT mirror when setConfig reports success:false', async () => {
+        global.window.electronAPI.setConfig.mockResolvedValue({ success: false });
+        buildRecordingController();
+
+        // Seed settings panel with a known value so we can detect drift.
+        document.getElementById('language-select').value = 'en';
+
+        const recLang = document.getElementById('record-language-select');
+        recLang.value = 'ja';
+        fireChange(recLang);
+        await new Promise((r) => setImmediate(r));
+
+        expect(document.getElementById('language-select').value).toBe('en');
+    });
+
+    test('Recording -> Settings: do NOT mirror when setConfig throws', async () => {
+        global.window.electronAPI.setConfig.mockRejectedValue(new Error('boom'));
+        buildRecordingController();
+
+        document.getElementById('translate-checkbox').checked = false;
+
+        const recTranslate = document.getElementById('record-translate-checkbox');
+        recTranslate.checked = true;
+        fireChange(recTranslate);
+        await new Promise((r) => setImmediate(r));
+
+        expect(document.getElementById('translate-checkbox').checked).toBe(false);
+    });
+
+    test('Settings panel save mirrors language/translate into Recording screen', async () => {
+        const controller = buildSettingsController();
+
+        document.getElementById('model-select').value = 'base';
+        document.getElementById('language-select').value = 'pt';
+        document.getElementById('threads-select').value = '4';
+        document.getElementById('translate-checkbox').checked = true;
+
+        await controller.saveSettings();
+
+        expect(document.getElementById('record-language-select').value).toBe('pt');
+        expect(document.getElementById('record-translate-checkbox').checked).toBe(true);
+        expect(global.window.electronAPI.setConfig).toHaveBeenCalledWith(
+            expect.objectContaining({ language: 'pt', translate: true })
+        );
+    });
+
+    test('Settings panel save with Auto-detect persists "auto" but keeps UI empty', async () => {
+        const controller = buildSettingsController();
+
+        document.getElementById('model-select').value = 'base';
+        document.getElementById('language-select').value = '';
+        document.getElementById('threads-select').value = '4';
+        document.getElementById('translate-checkbox').checked = false;
+
+        await controller.saveSettings();
+
+        expect(global.window.electronAPI.setConfig).toHaveBeenCalledWith(
+            expect.objectContaining({ language: 'auto' })
+        );
+        expect(document.getElementById('record-language-select').value).toBe('');
+    });
+
+    test('Settings panel save does NOT mirror to Recording screen when setConfig rejects', async () => {
+        global.window.electronAPI.setConfig.mockRejectedValue(new Error('nope'));
+        const controller = buildSettingsController();
+
+        document.getElementById('record-language-select').value = 'en';
+        document.getElementById('record-translate-checkbox').checked = false;
+        document.getElementById('model-select').value = 'base';
+        document.getElementById('language-select').value = 'ko';
+        document.getElementById('threads-select').value = '4';
+        document.getElementById('translate-checkbox').checked = true;
+
+        await controller.saveSettings();
+
+        expect(document.getElementById('record-language-select').value).toBe('en');
+        expect(document.getElementById('record-translate-checkbox').checked).toBe(false);
+    });
+
+    test('Settings panel load maps persisted "auto" to empty in both UIs', async () => {
+        global.window.electronAPI.getConfig.mockResolvedValue({
+            model: 'base', language: 'auto', threads: 4, translate: false
+        });
+        const controller = buildSettingsController();
+
+        await controller.loadSettings();
+
+        expect(document.getElementById('language-select').value).toBe('');
+        expect(document.getElementById('record-language-select').value).toBe('');
+    });
+
+    test('Settings panel load mirrors language/translate into Recording screen', async () => {
+        global.window.electronAPI.getConfig.mockResolvedValue({
+            model: 'base', language: 'it', threads: 4, translate: true
+        });
+        const controller = buildSettingsController();
+
+        await controller.loadSettings();
+
+        expect(document.getElementById('record-language-select').value).toBe('it');
+        expect(document.getElementById('record-translate-checkbox').checked).toBe(true);
+    });
+});

--- a/tests/unit/renderer/recordingLanguageSettings.test.js
+++ b/tests/unit/renderer/recordingLanguageSettings.test.js
@@ -289,6 +289,37 @@ describe('Recording-screen Language Settings', () => {
         expect(document.getElementById('record-language-select').value).toBe('');
     });
 
+    test('Recording rollback uses currently persisted value, not a stale cache, after Settings panel saved a new language', async () => {
+        // Start with persisted language=en
+        global.window.electronAPI.getConfig.mockResolvedValue({ language: 'en', translate: false });
+        const recording = buildRecordingController();
+        await recording._loadVADSettingsIntoUI();
+
+        // Settings panel persists language=ko
+        const settings = buildSettingsController();
+        document.getElementById('model-select').value = 'base';
+        document.getElementById('language-select').value = 'ko';
+        document.getElementById('threads-select').value = '4';
+        document.getElementById('translate-checkbox').checked = false;
+        await settings.saveSettings();
+        // From now on, getConfig reflects the new persisted state
+        global.window.electronAPI.getConfig.mockResolvedValue({ language: 'ko', translate: false });
+
+        // Recording screen now shows 'ko' (mirrored by Settings panel save)
+        expect(document.getElementById('record-language-select').value).toBe('ko');
+
+        // User changes Recording screen to 'ja' but the save fails
+        global.window.electronAPI.setConfig.mockResolvedValueOnce({ success: false, message: 'no' });
+        const recLang = document.getElementById('record-language-select');
+        recLang.value = 'ja';
+        fireChange(recLang);
+        await new Promise((r) => setImmediate(r));
+
+        // Rollback MUST restore the current persisted value 'ko', not stale 'en'
+        expect(recLang.value).toBe('ko');
+        expect(document.getElementById('language-select').value).toBe('ko');
+    });
+
     test('Settings panel load mirrors language/translate into Recording screen', async () => {
         global.window.electronAPI.getConfig.mockResolvedValue({
             model: 'base', language: 'it', threads: 4, translate: true


### PR DESCRIPTION
Duplicates the Language Settings card (Transcription Language + Translate to English) into the Recording tab.

## Changes
- New Language Settings card under #record-tab with #record-language-select and #record-translate-checkbox.
- Recording-screen handlers persist via electronAPI.setConfig and mirror into the Settings-panel controls.
- Settings panel mirrors language/translate into the Recording-screen copies on save/load.
- '' <-> 'auto' mapping at both UI boundaries so Auto-detect round-trips correctly.
- Settings panel mirrors immediately after setConfig succeeds so unrelated section failures cannot desync the UIs.
- Recording-screen failed saves reload the live persisted value (no stale local cache).
- Per-field save sequence drops stale in-flight results to prevent overlapping-save races.

## Tests
tests/unit/renderer/recordingLanguageSettings.test.js — 15 tests covering auto-detect mapping, two-way sync, failure/cancel paths, cross-controller stale-rollback, and overlapping-save race.